### PR TITLE
Improved main "content stripping" process

### DIFF
--- a/remover.py
+++ b/remover.py
@@ -51,6 +51,10 @@ class PdfEnhancedFileWriter(PdfFileWriter):
             b_('G'):  'grayscale', # color
 
             b_('re'): 'rectangle',
+
+            b_('l'): 'line', # line
+            b_('m'): 'line', # start line
+            b_('S'): 'line', # stroke(paint) line
         }
 
         if operator in operator_types:
@@ -66,7 +70,7 @@ class PdfEnhancedFileWriter(PdfFileWriter):
 
             operator_type = self._getOperatorType(operator)
 
-            if operator_type == 'text' or operator_type == 'rectangle':
+            if operator_type == 'text' or operator_type == 'rectangle' or operator_type == 'line':
                 return operator_type
 
         return False
@@ -93,7 +97,6 @@ class PdfEnhancedFileWriter(PdfFileWriter):
                 content = ContentStream(content, pageRef)
 
             _operations    = []
-            seq_graphics   = False
             last_font_size = 0
 
             for operator_index, (operands, operator) in enumerate(content.operations):
@@ -121,13 +124,6 @@ class PdfEnhancedFileWriter(PdfFileWriter):
                         if ignoreByteStringObject:
                             if not isinstance(operands[0][i], TextStringObject):
                                 operands[0][i] = TextStringObject()
-
-                # lower q and upper Q signaling graphic sequence start & stop
-                # although the right way is to check coloring between q&Q operators, tested documents showed that many coloring operations happens outside that sequence
-                if operator == b_('q'):
-                    seq_graphics = True
-                if operator == b_('Q'):
-                    seq_graphics = False
 
 
                 operator_type = self._getOperatorType(operator)

--- a/remover.py
+++ b/remover.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from PyPDF2 import PdfFileWriter, PdfFileReader
+from PyPDF2 import PdfFileReader, PdfFileWriter
+from PyPDF2.pdf import ContentStream
+from PyPDF2.generic import NumberObject, TextStringObject, NameObject
+from PyPDF2.utils import b_
+
 from tkinter import *
 from tkinter.filedialog import *
 import PyPDF2 as pypdf
@@ -13,6 +17,107 @@ def resource_path(relative_path):
         return os.path.join(sys._MEIPASS, relative_path)
     return os.path.join(os.path.abspath("."), relative_path)
 
+
+class PdfEnhancedFileWriter(PdfFileWriter):
+
+    def getMinimumRectangleWidth(self, fontSize, minimumNumberOfLetters = 1.5):
+        return fontSize * minimumNumberOfLetters
+
+    def removeWordStyle(self, ignoreByteStringObject=False):
+        """
+        Removes imported styles from Word - Path Constructors rectangles - from this output.
+
+        :param bool ignoreByteStringObject: optional parameter
+            to ignore ByteString Objects.
+        """
+        pages = self.getObject(self._pages)['/Kids']
+        for j in range(len(pages)):
+            page = pages[j]
+            pageRef = self.getObject(page)
+            content = pageRef['/Contents'].getObject()
+
+            if not isinstance(content, ContentStream):
+                content = ContentStream(content, pageRef)
+
+            _operations = []
+            seq_graphics = False
+            last_font_size = 0
+
+            for operands, operator in content.operations:
+
+                if operator == b_('Tf') and operands[0][:2] == '/F':
+                    last_font_size = operands[1].as_numeric()
+
+                if operator == b_('Tj'):
+                    text = operands[0]
+                    if ignoreByteStringObject:
+                        if not isinstance(text, TextStringObject):
+                            operands[0] = TextStringObject()
+                elif operator == b_("'"):
+                    text = operands[0]
+                    if ignoreByteStringObject:
+                        if not isinstance(text, TextStringObject):
+                            operands[0] = TextStringObject()
+                elif operator == b_('"'):
+                    text = operands[2]
+                    if ignoreByteStringObject:
+                        if not isinstance(text, TextStringObject):
+                            operands[2] = TextStringObject()
+                elif operator == b_("TJ"):
+                    for i in range(len(operands[0])):
+                        if ignoreByteStringObject:
+                            if not isinstance(operands[0][i], TextStringObject):
+                                operands[0][i] = TextStringObject()
+
+
+
+                # lower q and upper Q are
+                if operator == b_('q'):
+                    seq_graphics = True
+                if operator == b_('Q'):
+                    seq_graphics = False
+
+                # changing all (text) coloring to black (removing all text highlighting that's using a text color)
+                # removing (text) color completely results in wierd coloring (blue text turns yellow, probably because of another color layers)
+                if seq_graphics:
+
+                    # on RGB
+                    if operator in [b_('rg'), b_('RG')]:
+                        operands = [NumberObject(0), NumberObject(0), NumberObject(0)]
+
+                    # on CMYK
+                    if operator in [b_('k'), b_('K')]:
+                        operands = [NumberObject(0), NumberObject(0), NumberObject(0), NumberObject(1)]
+
+                    # on Gray Scale
+                    if operator in [b_('g'), b_('G')]:
+                        operands = [NumberObject(0)]
+
+
+
+
+                # remove styled rectangles (highlights, lines, etc.)
+                # the 're' operator is a Path Construction operator, creates a rectangle()
+                # presumably, that's the way word embedding all of it's graphics into a PDF when creating one
+                if operator == b_('re'):
+
+                    rectangle_width = operands[-2].as_numeric()
+                    rectangle_height = operands[-1].as_numeric()
+
+                    minWidth  = self.getMinimumRectangleWidth(last_font_size, 1) # (length of X letters at the current size)
+                    maxHeight = last_font_size + 6 # range to catch really big highlights
+                    minHeight = 1.5 # so that thin lines will not be removed
+
+                    # remove only style that:
+                        # it's width are bigger than the minimum
+                        # it's height is smaller than maximum and larger than minimum
+                    if rectangle_width > minWidth and rectangle_height > minHeight and rectangle_height <= maxHeight:
+                        continue
+
+                _operations.append((operands, operator))
+
+            content.operations = _operations
+            pageRef.__setitem__(NameObject('/Contents'), content)
 
 root=Tk()
 root.title('Answers Hider')
@@ -39,11 +144,11 @@ def load1():
 
 def add_to_writer(pdfsrc, writer):
     [writer.addPage(pdfsrc.getPage(i)) for i in range(pdfsrc.getNumPages())]
-    writer.removeImages()
+    writer.removeWordStyle()
 
 def remove_images():
-    print("remove rectangles and images")
-    writer = PdfFileWriter()
+    print("remove rectangles")
+    writer = PdfEnhancedFileWriter()
 
     output_filename= asksaveasfilename(filetypes=(('PDF File', '*.pdf'), ('All Files','*.*')))
     outputfile= open(output_filename+".pdf",'wb')
@@ -68,8 +173,8 @@ button2=Button(root, text="Remove answers", command=remove_images,font='Helvetic
 #Label(root, text="Good Luck!").grid(row=2, column=0, sticky=W)
 
 Label(root, text='''שימו לב,\n
-האפליקציה מסירה שכבה מסויימת של אובייקטים מהדף,\n
-ולכן תסיר גם תמונות או שרטוטים מסויימים, אם קיימים.\n
+האפליקציה מסירה אובייקטים מעוצבים שיובאו מוורד,\n
+ולכן יש סיכוי שתסיר גם טבלאות ואלמנטים עיצוביים אחרים, אם קיימים.\n
 הדף לא נפתח כראוי בתוכנות מסויימות של אדובי,\n
 הפתרון הפשוט לכך הוא לחצן ימני על הקובץ שנוצר,\n
 לחצן ימני > פתח באמצעות > כרום, פיירפוקס, או כל תוכנה אחרת שיודעת להציג פדף.\n

--- a/remover.py
+++ b/remover.py
@@ -5,11 +5,12 @@ from PyPDF2.pdf import ContentStream
 from PyPDF2.generic import NumberObject, TextStringObject, NameObject
 from PyPDF2.utils import b_
 
-from tkinter import *
-from tkinter.filedialog import *
-import PyPDF2 as pypdf
+from tkinter import Tk, Label, Button, StringVar
+from tkinter.filedialog import askopenfilename, asksaveasfilename
+from tkinter.constants import N,S,W,E, LEFT, TOP, RIGHT, BOTTOM
 import sys, os
 import tkinter.font as font
+
 
 
 def resource_path(relative_path):
@@ -32,15 +33,15 @@ class PdfEnhancedFileWriter(PdfFileWriter):
         """
         pages = self.getObject(self._pages)['/Kids']
         for j in range(len(pages)):
-            page = pages[j]
+            page    = pages[j]
             pageRef = self.getObject(page)
             content = pageRef['/Contents'].getObject()
 
             if not isinstance(content, ContentStream):
                 content = ContentStream(content, pageRef)
 
-            _operations = []
-            seq_graphics = False
+            _operations    = []
+            seq_graphics   = False
             last_font_size = 0
 
             for operands, operator in content.operations:
@@ -69,31 +70,28 @@ class PdfEnhancedFileWriter(PdfFileWriter):
                             if not isinstance(operands[0][i], TextStringObject):
                                 operands[0][i] = TextStringObject()
 
-
-
-                # lower q and upper Q are
+                # lower q and upper Q signaling graphic sequence start & stop
                 if operator == b_('q'):
                     seq_graphics = True
                 if operator == b_('Q'):
                     seq_graphics = False
 
+
                 # changing all (text) coloring to black (removing all text highlighting that's using a text color)
                 # removing (text) color completely results in wierd coloring (blue text turns yellow, probably because of another color layers)
                 if seq_graphics:
 
-                    # on RGB
+                    # Blacken RGB colors
                     if operator in [b_('rg'), b_('RG')]:
                         operands = [NumberObject(0), NumberObject(0), NumberObject(0)]
 
-                    # on CMYK
+                    # Blacken CMYK colors
                     if operator in [b_('k'), b_('K')]:
                         operands = [NumberObject(0), NumberObject(0), NumberObject(0), NumberObject(1)]
 
-                    # on Gray Scale
+                    # Blacken Gray Scale colors
                     if operator in [b_('g'), b_('G')]:
                         operands = [NumberObject(0)]
-
-
 
 
                 # remove styled rectangles (highlights, lines, etc.)
@@ -101,7 +99,7 @@ class PdfEnhancedFileWriter(PdfFileWriter):
                 # presumably, that's the way word embedding all of it's graphics into a PDF when creating one
                 if operator == b_('re'):
 
-                    rectangle_width = operands[-2].as_numeric()
+                    rectangle_width  = operands[-2].as_numeric()
                     rectangle_height = operands[-1].as_numeric()
 
                     minWidth  = self.getMinimumRectangleWidth(last_font_size, 1) # (length of X letters at the current size)
@@ -119,23 +117,23 @@ class PdfEnhancedFileWriter(PdfFileWriter):
             content.operations = _operations
             pageRef.__setitem__(NameObject('/Contents'), content)
 
-root=Tk()
+root = Tk()
 root.title('Answers Hider')
 #root.iconbitmap( resource_path('./icon.ico'))
 pdf_list = []
 
 
-filename1=StringVar()
-src_pdf=StringVar()
+filename1 = StringVar()
+src_pdf   = StringVar()
 
 def load_pdf(filename):
     f = open(filename,'rb')
-    return pypdf.PdfFileReader(f)
+    return PdfFileReader(f)
 
 def load1():
     f = askopenfilename(filetypes=(('PDF File', '*.pdf'), ('All Files','*.*')))
     filename1.set(f.split('/')[-1])
-    src_pdf=f
+    src_pdf = f
     print(f)
     print(src_pdf)
     pdf1 = load_pdf(f)
@@ -148,10 +146,9 @@ def add_to_writer(pdfsrc, writer):
 
 def remove_images():
     print("remove rectangles")
-    writer = PdfEnhancedFileWriter()
-
-    output_filename= asksaveasfilename(filetypes=(('PDF File', '*.pdf'), ('All Files','*.*')))
-    outputfile= open(output_filename+".pdf",'wb')
+    writer          = PdfEnhancedFileWriter()
+    output_filename = asksaveasfilename(filetypes = (('PDF File', '*.pdf'), ('All Files','*.*')))
+    outputfile      = open(output_filename + ".pdf",'wb')
 
     add_to_writer(pdf_list[0], writer)
 
@@ -162,12 +159,12 @@ def remove_images():
     root.quit()
 
 ##Label(root, text="Rectangles remover").grid(row=0, column=2, sticky=E)
-button1=Button(root, text="Choose file", command=load1, height = 5, width = 14).grid(row=1, column=0)
-Label(root, textvariable=filename1,width=20).grid(row=1, column=1, sticky=(N,S,E,W))
+Button(root, text="Choose file", command=load1, height=5, width=14).grid(row=1, column=0)
+Label(root, textvariable=filename1, width=20).grid(row=1, column=1, sticky=(N,S,E,W))
 #photo= PhotoImage(file=resource_path('./button_pic.png'))
 
 #Button(root, text="Remove answers",image=photo, command=remove_images, width=100, height=120).grid(row=1, column=2,sticky=E)
-button2=Button(root, text="Remove answers", command=remove_images,font='Helvetica 12 bold', fg="red", height =4).grid(row=1, column=2,sticky=E)
+Button(root, text="Remove answers", command=remove_images, font='Helvetica 12 bold', fg="red", height=4).grid(row=1, column=2, sticky=E)
 
 #Label(root, text="Remove Answers^^").grid(row=2, column=2, sticky=E)
 #Label(root, text="Good Luck!").grid(row=2, column=0, sticky=W)
@@ -185,7 +182,7 @@ Label(root, text='''שימו לב,\n
 
 
 for child in root.winfo_children():
-    child.grid_configure(padx=10,pady=10)
+    child.grid_configure(padx=10, pady=10)
 
 root.mainloop()
 


### PR DESCRIPTION
Added a new way for the app to identify and delete styles (mainly text highlights and text colors).
Photos, images and other visual data are no longer will be erased with highlights.

The solution is not perfect, and I tried my best with the usage of pypdf2 to identify only text highlights and not other imported styles from Word (line underlines, strikethroughs, tables, etc.)

You are welcome to tinker and change the logic values, but I think even in the current state it can bring real value for you and other students.